### PR TITLE
Fix a broken link

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -32,7 +32,7 @@ export default function FAQ() {
           club, a monthly fee, and an hourly usage rate. Specific pricing
           details will be provided as we approach club operations.
         </p>
-        <Link href='/membership-info'>Membership Info</Link>
+        <Link href='/being-a-member'>Membership Info</Link>
       </section>
       <section>
         <h5>Can I join if I don&apos;t have a pilot&apos;s license?</h5>


### PR DESCRIPTION
The `Membership Info` link on the FAQ page has been fixed to point to the correct new path.